### PR TITLE
Give Netdata full permissions for cloud configuration folder

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,8 @@ platforms:
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian11}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
     pre_build_image: true
 provisioner:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
     state: directory
     owner: "netdata"
     group: "netdata"
-    mode: "0600"
+    mode: "0770"
 
 - name: Copy cloud.conf
   copy:
@@ -35,6 +35,6 @@
     dest: /var/lib/netdata/cloud.d/cloud.conf
     owner: "netdata"
     group: "netdata"
-    mode: "0600"
+    mode: "0770"
   notify:
     - "Restart Netdata"


### PR DESCRIPTION
Netdata started showing "ads" again for Netdata Cloud on the dashboard. While the original fix from July 2022 seemed to work for a while, I guess one of the updates broke it.

Giving Netdata full permissions over the cloud configuration folder seems to fix the issue.