### PR TITLE
Skip certificate verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] docker
+        run: pip3 install ansible molecule molecule-docker
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,8 @@ jobs:
     strategy:
       matrix:
         distro:
-          - ubuntu1804
           - ubuntu2004
-          - debian9
+          - ubuntu2204
           - debian10
           - debian11
 

--- a/templates/stream.conf.j2
+++ b/templates/stream.conf.j2
@@ -3,6 +3,7 @@
     destination = {{ netdata_client_stream_destination | mandatory }}
     api key = {{ netdata_client_stream_key | mandatory }}
     CAfile = /etc/netdata/ssl/cert.pem
+    ssl skip certificate verification = yes
     timeout seconds = 60
     send charts matching = *
     buffer size bytes = 1048576


### PR DESCRIPTION
According to the documentation of Netdata, if you use self-signed certificates, as we do in our setup, you need to skip the verification of the certificate. The traffic remains encrypted and you still need to have the parent node's certificate in order to establish the connection.

Reference: https://learn.netdata.cloud/docs/deployment-in-production/streaming-and-replication/streaming-configuration-reference#streamconf

This PR also fixes the Molecule pipeline.