### PR TITLE
Remove `cloud.conf` from role

### DIFF
--- a/files/cloud.d/cloud.conf
+++ b/files/cloud.d/cloud.conf
@@ -1,2 +1,0 @@
-[global]
-enabled = no

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -51,6 +51,6 @@ galaxy_info:
     #       Maximum 20 tags per role.
 
 dependencies:
-  - {role: simplificator.netdata_installation}
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+  - role: simplificator.netdata_installation
+    netdata_installation_disable_cloud: yes
+    netdata_installation_monitor_docker: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,21 +20,3 @@
   notify:
     - Restart Netdata
   become: true
-
-- name: Create cloud configuration directory
-  file:
-    path: /var/lib/netdata/cloud.d
-    state: directory
-    owner: "netdata"
-    group: "netdata"
-    mode: "0770"
-
-- name: Copy cloud.conf
-  copy:
-    src: cloud.d/cloud.conf
-    dest: /var/lib/netdata/cloud.d/cloud.conf
-    owner: "netdata"
-    group: "netdata"
-    mode: "0770"
-  notify:
-    - "Restart Netdata"


### PR DESCRIPTION
This has been moved to the installation role, see https://github.com/simplificator/ansible-role-netdata_installation/pull/29.